### PR TITLE
Add CSV upload for providers

### DIFF
--- a/app/admin/admin.py
+++ b/app/admin/admin.py
@@ -51,8 +51,9 @@ class ProviderView(ModelView):
             file_content = form.file.data.stream.read().decode('utf-8')
             with StringIO(file_content) as csv_file:
                 csv_file_reader = csv.DictReader(csv_file, fieldnames=CSV_SCHEMA)
-                for index, item in enumerate(csv_file_reader):
-                    record = Provider.from_dict(item, index)
+                next(csv_file_reader)  # Skip the header row
+                for item in csv_file_reader:
+                    record = Provider.from_dict(item)
                     # Merge updates or inserts the record if it does not exist
                     db.session.merge(record)
                 db.session.commit()

--- a/app/admin/admin.py
+++ b/app/admin/admin.py
@@ -1,3 +1,5 @@
+import csv
+from io import StringIO
 import os.path as op
 
 from flask import request, redirect, Response, flash, url_for
@@ -11,6 +13,7 @@ from app import app, db
 from app.provider import Provider
 from app.application import Application
 from app.admin import ProviderImportForm
+from app.admin.forms import CSV_SCHEMA
 
 admin = Admin(app, name="Admin", template_mode="bootstrap3")
 
@@ -38,16 +41,35 @@ class ApplicationView(ModelView):
 
 class ProviderView(ModelView):
     can_export = True
+    list_template = 'admin/providers.html'  # Extending the list view to allow for CSV import
 
-    @expose('/import/', methods=['POST'])
+    @expose('/import', methods=['GET', 'POST'])
     def import_file(self):
         form = ProviderImportForm()
         if form.validate_on_submit():
-            # TODO: Check the contents for its API
-            file_content = form.file.data
-            # TODO: Parse the content and store it in db
+            # form.file.data returns a Workzeug FileStorage object, .stream returns the tempfile w/CSV data in bytearray
+            file_content = form.file.data.stream.read().decode('utf-8')
+            with StringIO(file_content) as csv_file:
+                csv_file_reader = csv.DictReader(csv_file, fieldnames=CSV_SCHEMA)
+                for index, item in enumerate(csv_file_reader):
+                    record = Provider(**{
+                        'id': index,
+                        'name': item['name'],
+                        'speciality': item['speciality'],
+                        'address': item['address'],
+                        'city': item['city'],
+                        'state': item['state'],
+                        'zip': item['zip'],
+                        'lat': float(item['lat']),
+                        'lng': float(item['lng'])
+                    })
+                    # merge will update or insert if the entry does not exist
+                    db.session.merge(record)
+                db.session.commit()
+
             flash('Providers imported successfully.')
-            return redirect(url_for('admin'))
+            return redirect(url_for('provider.index_view'))
+        return self.render('admin/import.html', form=form)
 
 
 # Applications

--- a/app/admin/admin.py
+++ b/app/admin/admin.py
@@ -52,18 +52,8 @@ class ProviderView(ModelView):
             with StringIO(file_content) as csv_file:
                 csv_file_reader = csv.DictReader(csv_file, fieldnames=CSV_SCHEMA)
                 for index, item in enumerate(csv_file_reader):
-                    record = Provider(**{
-                        'id': index,
-                        'name': item['name'],
-                        'speciality': item['speciality'],
-                        'address': item['address'],
-                        'city': item['city'],
-                        'state': item['state'],
-                        'zip': item['zip'],
-                        'lat': float(item['lat']),
-                        'lng': float(item['lng'])
-                    })
-                    # merge will update or insert if the entry does not exist
+                    record = Provider.from_dict(item, index)
+                    # Merge updates or inserts the record if it does not exist
                     db.session.merge(record)
                 db.session.commit()
 

--- a/app/admin/admin.py
+++ b/app/admin/admin.py
@@ -47,18 +47,18 @@ class ProviderView(ModelView):
     def import_file(self):
         form = ProviderImportForm()
         if form.validate_on_submit():
-            # form.file.data returns a Workzeug FileStorage object, .stream returns the tempfile w/CSV data in bytearray
+            # Coerce form.file.data to a stream to read CSV data
             file_content = form.file.data.stream.read().decode('utf-8')
             with StringIO(file_content) as csv_file:
                 csv_file_reader = csv.DictReader(csv_file, fieldnames=CSV_SCHEMA)
                 next(csv_file_reader)  # Skip the header row
                 for item in csv_file_reader:
                     record = Provider.from_dict(item)
-                    # Merge updates or inserts the record if it does not exist
+                    # Update or insert the record into the db.
                     db.session.merge(record)
                 db.session.commit()
 
-            flash('Providers imported successfully.')
+            flash('Provider info imported successfully.')
             return redirect(url_for('provider.index_view'))
         return self.render('admin/import.html', form=form)
 

--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -1,7 +1,8 @@
 from flask_wtf import FlaskForm as Form
 from flask_wtf.file import FileField, FileRequired
 from wtforms import ValidationError
-from app.provider.models import CSV_SCHEMA
+
+CSV_SCHEMA = ['id', 'name', 'speciality', 'address', 'city', 'state', 'zip', 'lat', 'lng']
 
 
 class FileSizeValidator(object):

--- a/app/admin/forms.py
+++ b/app/admin/forms.py
@@ -1,35 +1,52 @@
 from flask_wtf import FlaskForm as Form
-from wtforms import FileField
-from wtforms.validators import (
-    DataRequired,
-)
+from flask_wtf.file import FileField, FileRequired
+from wtforms import ValidationError
+from app.provider.models import Provider
+
+CSV_SCHEMA = None
+DB_SCHEMA = [item for item in dir(Provider) if '__' not in item]  # Remove builtin functions from the list
 
 
 class FileSizeValidator(object):
-    def __init__(self, message=None, max_size=int(5e6)):
+    def __init__(self, message=None, max_size=5*1024*1024):  # 5MB
+        self.max_size = max_size
         if message is None:
-            message = u'The file size exceeded max_size({})'.format(max_size)
+            message = u'The file size exceeded max_size({})'.format(self.max_size)
         self.message = message
 
     def __call__(self, form, field):
         if field.data:
-            # TODO: Check if file size is within max_size
-            return
+            file_size = len(field.data.stream.read())
+            field.data.stream.seek(0)  # Cleanup for the user
+            if file_size > self.max_size:
+                raise ValidationError(self.message)
 
 
 class CSVFileValidator(object):
-    def __init__(self, message=None):
-        if message is None:
-            message = u'The provided file didn\'t fit the specification.'
-        self.message = message
+    def __init__(self, mime_message=None, header_message=None):
+        if mime_message is None:
+            mime_message = u'The provided file is not a CSV file.'
+        self.mime_message = mime_message
+        if header_message is None:
+            header_message = u'The provided CSV file does not conform to the database schema.' \
+                            + u' Illegal column in CSV: {}'
+        self.header_message = header_message
 
     def __call__(self, form, field):
+        global CSV_SCHEMA
         if field.data:
-            # TODO: Add logic to
-            #  a. Check if extension matches (csv)
-            #  b. Check that the file data is valid CSV
-            return
+            if field.data.mimetype != 'text/csv':
+                raise ValidationError(self.mime_message)
+
+            # Check that the uploaded CSV matches our schema
+            CSV_SCHEMA = field.data.stream.readline().decode('utf-8').strip().split(',')  # yikes. This creates a list
+                                                                                          # of the schema.
+            field.data.stream.seek(0)  # Cleanup for the user
+            for item in CSV_SCHEMA:
+                if item not in DB_SCHEMA:
+                    raise ValidationError(self.header_message.format(item))
 
 
 class ProviderImportForm(Form):
-    file = FileField(validators=[DataRequired(), FileSizeValidator(), CSVFileValidator()], description="Import Provider data from CSV file.")
+    file = FileField(validators=[FileRequired(), FileSizeValidator(), CSVFileValidator()],
+                     description="Import Provider data from CSV file.")

--- a/app/provider/models.py
+++ b/app/provider/models.py
@@ -1,7 +1,5 @@
 from app import db
 
-CSV_SCHEMA = ['id', 'name', 'speciality', 'address', 'city', 'state', 'zip', 'lat', 'lng']
-
 
 class Provider(db.Model):
     __tablename__ = 'providers'

--- a/app/provider/models.py
+++ b/app/provider/models.py
@@ -9,7 +9,7 @@ class Provider(db.Model):
                    nullable=False,
                    autoincrement=True,
                    primary_key=True)
-    name = db.Column(db.String, nullable=False, unique=True)
+    name = db.Column(db.String, nullable=False)
     speciality = db.Column(db.String)
     address = db.Column(db.String, nullable=False)
     city = db.Column(db.String, nullable=False)

--- a/app/provider/models.py
+++ b/app/provider/models.py
@@ -1,5 +1,7 @@
 from app import db
 
+CSV_SCHEMA = ['id', 'name', 'speciality', 'address', 'city', 'state', 'zip', 'lat', 'lng']
+
 
 class Provider(db.Model):
     __tablename__ = 'providers'
@@ -26,9 +28,9 @@ class Provider(db.Model):
     )
 
     @staticmethod
-    def from_dict(d: dict, index: int):
+    def from_dict(d: dict):
         return Provider(**{
-            'id': index,
+            'id': d['id'],
             'name': d['name'],
             'speciality': d['speciality'],
             'address': d['address'],

--- a/app/provider/models.py
+++ b/app/provider/models.py
@@ -2,7 +2,6 @@ from app import db
 
 
 class Provider(db.Model):
-
     __tablename__ = 'providers'
 
     id = db.Column(db.Integer,
@@ -25,3 +24,17 @@ class Provider(db.Model):
         db.CheckConstraint(lng <= 180, name="Longitude upper range check"),
         {},
     )
+
+    @staticmethod
+    def from_dict(d: dict, index: int):
+        return Provider(**{
+            'id': index,
+            'name': d['name'],
+            'speciality': d['speciality'],
+            'address': d['address'],
+            'city': d['city'],
+            'state': d['state'],
+            'zip': d['zip'],
+            'lat': float(d['lat']),
+            'lng': float(d['lng'])
+        })

--- a/app/templates/admin/import.html
+++ b/app/templates/admin/import.html
@@ -1,6 +1,6 @@
 {% extends 'admin/master.html' %}
 {% block body %}
-    <h3>Please select a CSV file to upload.</h3>
+    <h3>Select a CSV file to import to the database:</h3>
     <form method="POST" action="{{ url_for('provider.import_file') }}" enctype="multipart/form-data">
         <p>{{ form.hidden_tag() }}</p>
         <p>{{ form.file }}</p>

--- a/app/templates/admin/import.html
+++ b/app/templates/admin/import.html
@@ -1,0 +1,12 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+    <h3>Please select a CSV file to upload.</h3>
+    <form method="POST" action="{{ url_for('provider.import_file') }}" enctype="multipart/form-data">
+        <p>{{ form.hidden_tag() }}</p>
+        <p>{{ form.file }}</p>
+        <button type="submit" class="btn btn-primary">Upload</button>
+        {% for error in form.file.errors %}
+            <span style="color: red;">{{ error }}</span>
+        {% endfor %}
+    </form>
+{% endblock %}

--- a/app/templates/admin/providers.html
+++ b/app/templates/admin/providers.html
@@ -1,0 +1,8 @@
+{% extends 'admin/model/list.html' %}
+
+{% block model_menu_bar %}
+    {{ super() }}
+    <div class="btn btn-title right">
+        <a href="{{ url_for('provider.import_file') }}">Upload</a>
+    </div>
+{% endblock %}

--- a/app/templates/admin/providers.html
+++ b/app/templates/admin/providers.html
@@ -2,7 +2,7 @@
 
 {% block model_menu_bar %}
     {{ super() }}
-    <div class="btn btn-title right">
-        <a href="{{ url_for('provider.import_file') }}">Upload</a>
+    <div class="btn btn-title">
+        <a href="{{ url_for('provider.import_file') }}">Import</a>
     </div>
 {% endblock %}


### PR DESCRIPTION
The option to upload a CSV has been added via an "Upload" button on the provider's page in the Admin panel. (It's not perfectly aligned but at this point I'm at a loss, IT WORKS!) This feature will "INSERT OR REPLACE" entries in the order they are in the CSV, which is crude, but we have no other identifiers.

This also changes the database model to allow for names to be non-unique, as a few hospital names came up repeatedly in the random model.
**This will require a database refresh.** Run `python3 manage.py dropdb` then re-init with `python3 manage.py initdb`.